### PR TITLE
Rename `pluginConfig` to `inputs`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ const canonicalRoot = process.env.URL;
 module.exports = {
   onPostBuild: async ({
     constants: { BUILD_DIR },
-    pluginConfig: { entryPoints, staticDir },
+    inputs: { entryPoints, staticDir },
   }) => {
     const root = BUILD_DIR;
     const trimmedStaticDir = staticDir.trim().replace(/^\/*|\/*$/g, '');


### PR DESCRIPTION
The `pluginConfig` argument was renamed to `inputs`.