### PR TITLE
Rename `BUILD_DIR` to `PUBLISH_DIR`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,10 @@ const canonicalRoot = process.env.URL;
 
 module.exports = {
   onPostBuild: async ({
-    constants: { BUILD_DIR },
+    constants: { PUBLISH_DIR },
     pluginConfig: { entryPoints, staticDir },
   }) => {
-    const root = BUILD_DIR;
+    const root = PUBLISH_DIR;
     const trimmedStaticDir = staticDir.trim().replace(/^\/*|\/*$/g, '');
 
     const graph = new AssetGraph({ root, canonicalRoot });


### PR DESCRIPTION
The `BUILD_DIR` constant was renamed to `PUBLISH_DIR`.