### PR TITLE
Remove return value

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -80,7 +80,5 @@ module.exports = {
         )
         .join('\n')
     );
-
-    return result;
   },
 };


### PR DESCRIPTION
Returning a value from the plugin event handlers will soon have a specific meaning (e.g. meant for cross-plugin communication) so at the moment, plugin event handlers should not return a value.